### PR TITLE
Retry requests to API when it's possibly waking up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",
+        "axios-retry": "^3.4.0",
         "dotenv": "^16.0.1",
         "fastify": "^4.5.3",
         "fastify-plugin": "^4.2.1",
@@ -18,6 +19,17 @@
       "devDependencies": {
         "ngrok": "^4.3.3",
         "nodemon": "^2.0.19"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
+      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@fastify/ajv-compiler": {
@@ -231,6 +243,15 @@
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/balanced-match": {
@@ -816,6 +837,17 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -1216,6 +1248,11 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1504,6 +1541,14 @@
     }
   },
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
+      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.11"
+      }
+    },
     "@fastify/ajv-compiler": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.2.0.tgz",
@@ -1685,6 +1730,15 @@
       "requires": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
+      }
+    },
+    "axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "balanced-match": {
@@ -2118,6 +2172,11 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
+    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2416,6 +2475,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "require-from-string": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.27.2",
+    "axios-retry": "^3.4.0",
     "dotenv": "^16.0.1",
     "fastify": "^4.5.3",
     "fastify-plugin": "^4.2.1",

--- a/src/clients/nenoy-api.js
+++ b/src/clients/nenoy-api.js
@@ -1,4 +1,5 @@
 const axios = require('axios')
+const axiosRetry = require('axios-retry')
 
 const {
     requestInterceptor,
@@ -15,6 +16,14 @@ const nenoyApi = axios.create({
       password: process.env.NENOY_API_PASS,
     },
     timeout: process.env.NENOY_API_TIMEOUT,
+})
+axiosRetry(nenoyApi, {
+    retries: process.env.NENOY_API_RETRY_MAX,
+    retryDelay: () => process.env.NENOY_API_RETRY_DELAY,
+    onRetry: (retryCount, error, requestConfig) => {
+        console.log(`Attempting retry number ${retryCount} after error: ${error}`)
+        return;
+    },
 })
 nenoyApi.interceptors.request.use(requestInterceptor, requestErrorInterceptor)
 nenoyApi.interceptors.response.use(responseInterceptor, responseErrorInterceptor)


### PR DESCRIPTION
Per Render.com's [Free Web Services](https://render.com/docs/free#free-web-services) doc, services are spun down after 15 mins of inactivity. It will take up to 30 secs to respond when waking up from this sleep.

This change adds a retry mechanism to resiliently handle such scenarios and not need the message to be resent.