### PR TITLE
Add option to deploy site on-demand

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,5 +1,6 @@
 const { Telegraf } = require('telegraf')
 const fastifyPlugin = require('fastify-plugin')
+const axios = require('axios')
 
 const gatekeeper = require('./middlewares/gatekeeper')
 const mainController = require('./controllers')
@@ -17,6 +18,9 @@ module.exports = fastifyPlugin(async (app) => {
         )
     })
     bot.help((ctx) => ctx.reply('Send me your puzzle results and I\'ll ship them to your website! 🚀' + `\n[Chat ID: ${ctx.chat.id}]`))
+    bot.command('deploysite', async () => {
+        await axios.post(process.env.BUILD_HOOK_SITE, {})
+    })
     bot.on('message', mainController)
 
     // Enable graceful stop

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -22,7 +22,7 @@ module.exports = fastifyPlugin(async (app) => {
 
     const formatMessage = {
         'building': (link) => `🚀 Deploy for galiarmero\\.dev ongoing\\.`,
-        'error': (link) => `🚩 Deploy for galiarmero\\.dev failed\\. See [logs](${link})\\.`,
+        'error': (link) => `🚩 Deploy for galiarmero\\.dev failed\\.\n\n\t• 🔎 View [logs](${link})\n\t• ▶️ /deploysite`,
         'ready': (link) => `✅ Deploy for galiarmero\\.dev succeeded\\.`,
     }
     app.post(`/events/website-deploys`, async (req, res) => {


### PR DESCRIPTION
Add option to trigger deploy of [galiarmero.dev](https://galiarmero.dev/) on-demand in case of retriable failures or if I just want to.

The command is `/deploysite`