### PR TITLE
Route website deploy request to API

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -18,9 +18,6 @@ module.exports = fastifyPlugin(async (app) => {
         )
     })
     bot.help((ctx) => ctx.reply('Send me your puzzle results and I\'ll ship them to your website! 🚀' + `\n[Chat ID: ${ctx.chat.id}]`))
-    bot.command('deploysite', async () => {
-        await axios.post(process.env.BUILD_HOOK_SITE, {})
-    })
     bot.on('message', mainController)
 
     // Enable graceful stop

--- a/src/clients/nenoy-api.js
+++ b/src/clients/nenoy-api.js
@@ -36,4 +36,14 @@ const addPuzzleScore = async (newPuzzleScore) => {
     return nenoyApi.post('/puzzle-scores', newPuzzleScore);
 }
 
+const deployWebsite = async () => {
+    return nenoyApi.post('/deploys/website', null, {
+        params: {
+            force: true,
+            title: 'Deploy triggered via @NenoyTheBot'
+        }
+    });
+}
+
 module.exports.addPuzzleScore = addPuzzleScore
+module.exports.deployWebsite = deployWebsite

--- a/src/controllers/deploys.js
+++ b/src/controllers/deploys.js
@@ -1,0 +1,34 @@
+const { deployWebsite } = require('../clients/nenoy-api')
+const { CAUSE, ERROR_MESSAGE } = require('../types/errors')
+const { identifyCauseType } = require('../middlewares/interceptors')
+
+const isDeploy = (ctx) => {
+    const { text } = ctx.update.message
+
+    if (text === '/deploysite') return true
+
+    return false
+}
+
+const handleDeploy = async (ctx) => {
+    const { text } = ctx.update.message
+
+    if (text !== '/deploysite') return
+
+    try {
+        await deployWebsite()
+    } catch (error) {
+        console.log(`Error encountered: ${error}`)
+        causeType = identifyCauseType(error)
+        console.log(`Cause type: ${causeType}`)
+        let reply = ERROR_MESSAGE[causeType]
+        if (causeType == CAUSE.ErrorResponse) {
+            reply += `: ${e.response.data.message}`
+        }
+
+        await ctx.reply(reply, { reply_to_message_id: ctx.message.message_id })
+    }
+}
+
+module.exports = handleDeploy
+module.exports.isDeploy = isDeploy

--- a/src/controllers/message-types.js
+++ b/src/controllers/message-types.js
@@ -1,5 +1,6 @@
 const MESSAGE_TYPES = {
     PUZZLE_SCORES: "puzzle-scores",
+    DEPLOYS: "deploys",
     INDECIPHERABLE: "indecipherable",
 }
 

--- a/src/controllers/type-mappings.js
+++ b/src/controllers/type-mappings.js
@@ -1,15 +1,19 @@
 const MESSAGE_TYPES = require('./message-types')
 const handlePuzzleScore = require('./puzzle-score')
+const handleDeploy = require('./deploys')
 const handleIndecipherable = require('./indecipherable')
 
 const { isPuzzleScore } = require('./puzzle-score')
+const { isDeploy } = require('./deploys')
 
 const DEDUCERS_BY_TYPE = {
     [MESSAGE_TYPES.PUZZLE_SCORES]: isPuzzleScore,
+    [MESSAGE_TYPES.DEPLOYS]: isDeploy,
 }
 
 const HANDLERS_BY_TYPE = {
     [MESSAGE_TYPES.PUZZLE_SCORES]: handlePuzzleScore,
+    [MESSAGE_TYPES.DEPLOYS]: handleDeploy,
     [MESSAGE_TYPES.INDECIPHERABLE]: handleIndecipherable,
 }
 


### PR DESCRIPTION
This is the result of a design decision to route deploy requests to `nenoy-api` instead of directly talking to Netlify. This offers some advantages:

1. `nenoy-the-bot` will only be dependent on one backing service, `nenoy-api`
2. `nenoy-api` becomes the single point of entry, allowing all types of deploys to be tracked, whether on-demand or periodic