### PR TITLE
Fix logic for deducing message type

### DIFF
--- a/src/controllers/concierge.js
+++ b/src/controllers/concierge.js
@@ -3,7 +3,7 @@ const { INDECIPHERABLE } = require('./message-types')
 
 const deduceMessageType = (ctx) =>
     Object.entries(DEDUCERS_BY_TYPE).reduce(
-        (deducedType, [type, isOfThisType]) => deducedType ?? isOfThisType(ctx) ? type : null,
+        (deducedType, [type, isOfThisType]) => deducedType ?? (isOfThisType(ctx) ? type : null),
         null
     )
     ?? INDECIPHERABLE


### PR DESCRIPTION
### Scenario

When sending a `puzzle-scores`, it is being deduced as a `deploys`.

### Root Cause

`deploys` was recently added as a new type, the second type supported by the bot. This exposed a faulty behavior in deducing the message type. When the `reduce` method already deduces `puzzle-scores` as the type, instead of skipping the type check + deduced type assignment for `deploy` element (through the nullish coalescing operator `??`), it instead evaluates `deducedType ?? isOfThisType(ctx)` as `true` since it results to `puzzle-scores`. Thus the `deducedType` becomes `type` which is `deploys`

```js
    Object.entries(DEDUCERS_BY_TYPE).reduce(
        (deducedType, [type, isOfThisType]) => deducedType ?? isOfThisType(ctx) ? type : null
       , null) 
```

### Solution

Group `isOfThisType(ctx) ? type : null` together so that it is only executed if `deducedType` is still null.