### PR TITLE
Send notification on missed once-daily deploys

### DIFF
--- a/src/event-handler/index.js
+++ b/src/event-handler/index.js
@@ -1,5 +1,6 @@
 const websiteDeployHandler = require('./website-deploy')
 const unplayedPuzzlesHandler = require('./unplayed-puzzles')
+const missedOnceDailyWebsiteDeploy = require('./missed-once-daily-website-deploy')
 
 const eventHandler = async (app, request, reply) => {
     const { eventType } = request.params
@@ -8,6 +9,8 @@ const eventHandler = async (app, request, reply) => {
             return websiteDeployHandler(app, request, reply)
         case 'unplayed-puzzles':
             return unplayedPuzzlesHandler(app, request, reply)
+        case 'missed-once-daily-website-deploy':
+            return missedOnceDailyWebsiteDeploy(app, request, reply)
         default:
             return reply.code(404).send()
     }

--- a/src/event-handler/missed-once-daily-website-deploy.js
+++ b/src/event-handler/missed-once-daily-website-deploy.js
@@ -1,0 +1,20 @@
+const missedOnceDailyWebsiteDeployHandler = async (app, request, reply) => {
+    console.log(request.body.lastSuccessfulDeployDate)
+    const lastSuccessfulDeployDate = new Date(request.body.lastSuccessfulDeployDate)
+    const message = `⚠️ galiarmero\\.dev was not deployed yesterday\\. ` +
+                    `Last successful deploy was ${lastSuccessfulDeployDate.toDateString()}\\.`
+
+    await Promise.all(app.config.NOTIF_CHAT_IDS.map(async (chatId) => {
+        await app.bot.telegram.sendMessage(
+            chatId,
+            message,
+            {
+                parse_mode: 'MarkdownV2',
+                disable_web_page_preview: true,
+            }
+        )
+    }))
+    return reply.send()
+}
+
+module.exports = missedOnceDailyWebsiteDeployHandler

--- a/src/event-handler/unplayed-puzzles.js
+++ b/src/event-handler/unplayed-puzzles.js
@@ -3,7 +3,7 @@ const PUZZLES = require('../config/puzzles')
 const unplayedPuzzlesHandler = async (app, request, reply) => {
     const { unplayedPuzzles } = request.body
 
-    if (!Array.isArray(unplayedPuzzles) || unplayedPuzzles.length == 0) return reply.send()
+    if (!Array.isArray(unplayedPuzzles) || unplayedPuzzles.length == 0) return reply.code(400).send()
 
     let reminder = unplayedPuzzles.reduce((message, puzzleId) => {
         const puzzle = PUZZLES[puzzleId]


### PR DESCRIPTION
I have doubts with specifically using `"yesterday"` in the messaging. But this event is emitted when the last deploy was before yesterday. So it's technically correct but assumes some knowledge of that logic. I also don't want to mention 'yesterday' in the endpoint path since my preference of when to check the last deploy against might change.